### PR TITLE
Revert "upgrade rest-client version to 1.7.3"

### DIFF
--- a/cbx_loco.gemspec
+++ b/cbx_loco.gemspec
@@ -32,7 +32,7 @@ TEXT
   s.add_dependency "colorize", "~> 0.8.1"
 
   s.add_dependency "rails", ">= 4.1", "< 5.3"
-  s.add_dependency "rest-client", "~> 1.7.3"
+  s.add_dependency "rest-client", "~> 1.6.7"
   s.add_dependency "rake", ">= 11.0", "<= 12.3.1"
   s.add_dependency "rubyzip", "~> 1.1"
 


### PR DESCRIPTION
Ok, I think I found the reason why it didn't occur before: we updated rest-client version from 1.6.7 to 1.7.3 in cbx_loco 2 days ago: https://github.com/cognibox/cbx_loco/commit/f140a5eb8fd58ecd8252241d5e7ec28693e1cb46 (but v 1.7.0 "Add support for SSL ciphers, and choose secure ones by default", while 2.0.1, that would fix the "key not found: :ciphers", would "Drop the old check for weak default TLS ciphers, and use the built-in Ruby defaults." https://github.com/rest-client/rest-client/blob/master/history.md )
 
Normally, Gemfile.lock locks the version of cbx_loco used by the Rails app to a given revision of a branch (so that change is not live in cbx, because we don't have the parallel PR for PLAT-308 that updates the loco revision in cbx4).
**I suspect the Jenkins build pulls the latest revision of the master branch from https://github.com/cognibox/cbx_loco, unlike cbx4.
 
In the meantime, I'll revert the commit to cbx_loco to revert it's master to 1.6.7.